### PR TITLE
Fix pallocator dependency versioning

### DIFF
--- a/clean
+++ b/clean
@@ -1,0 +1,5 @@
+#!/usr/bin/sh
+set -e
+
+cargo clean
+rm "$(rustc --print sysroot)/lib/rustlib/x86_64-postgres-linux-gnu/lib/*"

--- a/pallocator/Cargo.toml
+++ b/pallocator/Cargo.toml
@@ -5,5 +5,13 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-pgx = { version = "=0.5.0-beta.0", features = ["pg14"] }
+[dependencies.pgx-pg-sys]
+# pallocator only expects to be included in a graph which already features a pgx crate with:
+# - a crate version
+# - a "{PG_VERSION}" feature (which will probably be pg14)
+# Thus, we only need to make sure we enable the postgrestd feature for pgx-pg-sys,
+# and ask only for a version of pgx-pg-sys where that is possible.
+version = ">=0.5.0-beta.0"
+features = ["postgrestd"]
+git = "https://github.com/tcdi/pgx"
+branch = "develop"

--- a/pallocator/src/lib.rs
+++ b/pallocator/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use core::alloc::{GlobalAlloc, Layout};
-use pgx::pg_sys;
+use pgx_pg_sys as pg_sys;
 
 struct PostAlloc;
 


### PR DESCRIPTION
Move pallocator's dependency on pgx to a dependency on pgx-pg-sys. Because this crate will only be included in a dependency graph that includes a pgx-pg-sys with a specified version, a very lax strategy is preferred, permitting its opinions to be easily overridden.

Also includes a cleanup script.