### PR TITLE
Modify run script to work for aarch64

### DIFF
--- a/run
+++ b/run
@@ -2,9 +2,10 @@
 set -e
 
 sysroot="$(rustc --print sysroot)"
+machine="$(uname -m)"
 
 if [ -z "${STD_TARGET}" ]; then
-    STD_TARGET="x86_64-unknown-linux-postgres"
+    STD_TARGET="$machine-unknown-linux-postgres"
 fi
 
 main() {


### PR DESCRIPTION
### Notes
Let's use the machine name instead of hard-coding to x86 in STD_TARGET in `./run`

---

### Testing

Tested `./run install` for both x86 and aacrh64