### PR TITLE
Disable +outline-atomics

### DIFF
--- a/aarch64-postgres-linux-gnu.json
+++ b/aarch64-postgres-linux-gnu.json
@@ -5,7 +5,7 @@
     "dynamic-linking": true,
     "env": "gnu",
     "executables": true,
-    "features": "+outline-atomics",
+    "features": "-outline-atomics",
     "has-rpath": true,
     "has-thread-local": true,
     "llvm-target": "aarch64-unknown-linux-gnu",


### PR DESCRIPTION
Reported in Discord as a mysterious linking error. This is confirmed as fixing it.