### PR TITLE
Allow fs macros

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1208,10 +1208,11 @@ pub(crate) mod builtin {
     /// Compiling 'main.rs' and running the resulting binary will print "adiós".
     #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
+    #[rustc_builtin_macro]
     #[cfg_attr(not(test), rustc_diagnostic_item = "include_str_macro")]
     macro_rules! include_str {
         ($file:expr $(,)?) => {
-            ""
+            /* compiler built-in */
         };
     }
 
@@ -1249,10 +1250,11 @@ pub(crate) mod builtin {
     /// Compiling 'main.rs' and running the resulting binary will print "adiós".
     #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
+    #[rustc_builtin_macro]
     #[cfg_attr(not(test), rustc_diagnostic_item = "include_bytes_macro")]
     macro_rules! include_bytes {
         ($file:expr $(,)?) => {
-            b""
+            /* compiler built-in */
         };
     }
 


### PR DESCRIPTION
See https://github.com/tcdi/plrust/pull/214. These are likely better blocked via lints.