### PR TITLE
Add a diagnostic item for `include!`

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1361,6 +1361,7 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
+    #[cfg_attr(not(test), rustc_diagnostic_item = "include_macro")]
     macro_rules! include {
         ($file:expr $(,)?) => {{ /* compiler built-in */ }};
     }


### PR DESCRIPTION
I know there's some weird behavior around diagnostic items (is it a compile error to have these without changing the compiler?) so I'm not sure if we can do this.