### PR TITLE
For now, make `include_str!` and `include_bytes!` not builtin macros again

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1210,11 +1210,10 @@ pub(crate) mod builtin {
     /// Compiling 'main.rs' and running the resulting binary will print "adiós".
     #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
-    #[rustc_builtin_macro]
     #[cfg_attr(not(test), rustc_diagnostic_item = "include_str_macro")]
     macro_rules! include_str {
         ($file:expr $(,)?) => {
-            /* compiler built-in */
+            ""
         };
     }
 
@@ -1252,11 +1251,10 @@ pub(crate) mod builtin {
     /// Compiling 'main.rs' and running the resulting binary will print "adiós".
     #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
-    #[rustc_builtin_macro]
     #[cfg_attr(not(test), rustc_diagnostic_item = "include_bytes_macro")]
     macro_rules! include_bytes {
         ($file:expr $(,)?) => {
-            /* compiler built-in */
+            b""
         };
     }
 


### PR DESCRIPTION
Not ideal, and only *really* needed for `include_bytes!` for now (everything else goes through `FileLoader`)