### PR TITLE
Update to 1.71.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,14 @@ on:
       - rust-1.69.0
       - rust-1.70.0
       - rust-1.71.0
+      - rust-1.71.1
   pull_request:
     branches:
       - 1.67.1
       - rust-1.69.0
       - rust-1.70.0
       - rust-1.71.0
+      - rust-1.71.1
 
 jobs:
   test_x86_84:
@@ -114,7 +116,7 @@ jobs:
         export RUSTUP_HOME="$HOME/.rustup"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         source "$HOME/.cargo/env"
-        rustup toolchain install 1.71.0
+        rustup toolchain install 1.71.1
         cargo --version
 
     - name: Print env

--- a/UPDATING_POSTGRESTD.md
+++ b/UPDATING_POSTGRESTD.md
@@ -13,6 +13,9 @@ Then, the rough steps are as follows:
    3. `git subtree push -P library ~/work/postgrestd "$NEWVERSION-library"` (push the subtree. This will take 1h-2h, so find something else to do while it runs)
 3. `cd ~/work/postgrestd`
    1. `git subtree pull -P library . "$NEWVERSION-library"`
+
+      Note: If `git subtree pull ...` tells you that you're "Already up to date." in this step despite changing nothing, it may be because there were no commits which modified files under `library/` between `$OLDVERSION` and `$NEWVERSION`. This pretty much can only ever happen when for patch updates (for example, this happened between Rust 1.71.0 and 1.71.1).
+
    2. Resolve merge conflicts.
    3. Push and fix issues.
    4. Audit the new stdlib APIs and internals for changes and make sure nothing new is added that we should not have exposed from PL/Rust. There's no real guide to how to do that, though, just go through the changes and use your best judgement. (Note: This is usually very time consuming). In particular keep an eye out for:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.71.0"
+channel = "1.71.1"
 components = [ "rustfmt" ]
 targets = [ ]
 profile = "minimal"


### PR DESCRIPTION
Don't merge, this is just for CI and such.

There were no commits to `library/*` since 1.71.0, which really confused me; I ran the `git subtree push ...` part like 4 times today thinking I somehow messed it up or had my repo in a weird state (each time it takes a few hours...)

I added a note to the upgrading guide about this, in case it happens again. Other than that, the lack of changes upstream means this just tweaks a few version numbers in a couple places.